### PR TITLE
Update Club Binder, Club Binder contents; follow style guide

### DIFF
--- a/docs/administration/club-binder-contents.rst
+++ b/docs/administration/club-binder-contents.rst
@@ -1,67 +1,69 @@
-Club Binder contents
-====================
+####################
+Club binder contents
+####################
 
 This document is a table of contents for the RITlug club binder in the RIT
-clubs office.
+Clubs office.
 
 
-Club Center Info
-----------------
-
-*Club center information* \* Table of Contents \* Contact Information \*
-Resources and Referrals \* Sample Transition Binder Outline
-
+****************
+Club Center info
+****************
 
 History
--------
+=======
 
 - `RITlug club history`_
 
+At a future date, this may move into the Runbook.
 
-.. _`RITlug club history`: https://github.com/RITlug/history
-
-
-Club Info
----------
+Club info
+=========
 
 - `RITlug Runbook`_
 
 - RITlug Server Use Policy (from `RITlug/governance`_)
 
-- Outgoing Eboard Transition Discussion Topics (from clubs office)
-
-
-.. _`RITlug Runbook`: http://runbook.ritlug.com/
-.. _`RITlug/governance`: https://github.com/RITlug/governance
-
+- Outgoing Eboard Transition Discussion Topics (from Clubs office on request)
 
 Constitution
-------------
+============
 
 - `RITlug Constitution`
 
+At a future date, this may move into the Runbook.
   
-.. _`RITlug Constitution`: https://github.com/RITlug/governance
-
-
 Finances
---------
+========
 
-- RITlug budget report (from clubs office)
+- RITlug budget report (from Clubs office on request)
 
 
 Events
-------
+======
+
+- :doc:`../events/club-fairs`
+
+- :doc:`../events/meetings`
 
 
-Public Relations
-----------------
+Public relations
+================
 
 
 CampusGroups
-------------
+============
+
+- :doc:`campusgroups-management`
 
 
-Misc Info
----------
+Misc. info
+==========
 
+- :doc:`eboard-onboarding-offboarding`
+
+
+.. _`RITlug club history`: https://github.com/RITlug/history
+.. _`RITlug Runbook`: http://runbook.ritlug.com/
+.. _`RITlug/governance`: https://github.com/RITlug/governance
+.. _`RITlug Constitution`: https://github.com/RITlug/governance

--- a/docs/administration/club-binder.rst
+++ b/docs/administration/club-binder.rst
@@ -1,64 +1,62 @@
-Club Binder
-===========
+###########
+Club binder
+###########
 
 The RITlug club binder is a physical source of information about the club. It
 contains hard copies of the club documentation from GitHub, club accounts, and
 documentation from the RIT club office.
 
 The RITlug club binder is passed from president to president during executive
-board transitions. Even though most of RITlug's documentation is available or
-maintained as electronic records, the club binder should be **updated
-annually**.
+board transitions (see :doc:`eboard-onboarding-offboarding`). Even though most
+of RITlug's documentation is available or maintained as electronic records, the
+club binder should be **updated annually**.
 
 
-Contents
---------
+*****************
+Table of contents
+*****************
 
 See :doc:`club-binder-contents` to see the table of contents in the club
 binder. This is maintained as a separate document to be printed and inserted
 into the physical binder.
 
 
-Updating the Club Binder
-------------------------
+*******************
+Updating the binder
+*******************
 
-1. Print documents (using the instructions below)
-2. Replace updated pages in club binder
-3. Update log at front of section you updated in binder
+#. Print documents (using instructions below)
+#. Replace updated pages in binder
+#. Update log (at front of section you updated) in binder
 
 
 Printing updated documents
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+==========================
 
-- Club documents are printable via the rendered version of the Runbook, hosted
-  at `runbook.ritlug.com`_
+- Club documents are printable via the `rendered version`_ of the Runbook
 
 - To save on paper, only print updated pages
 
-
-.. _`runbook.ritlug.com`: http://runbook.ritlug.com/
-
-
 Club governance
-~~~~~~~~~~~~~~~
+===============
 
 Part of the club binder includes the club governance, like the constitution.
 The club governance documents are hosted in a different GitHub repo,
-`RITlug/governance`_. Follow these steps [#]_ to generate updated versions of
+`RITlug/governance`_. Follow `these steps`_ to generate updated versions of
 the governance documentation.
 
 - Clone `RITlug/governance`_, install dependencies, compile documents into PDFs
   from LATeX
 
-- Print generated PDFs (only print updated pages to save paper)
-
-
-.. [#] Advanced documentation can be found in the README of `RITlug/governance`_
-.. _`RITlug/governance`: https://github.com/RITlug/governance
-
+- Print generated PDFs (print updated pages to save paper)
 
 Club accounts
-~~~~~~~~~~~~~
+=============
 
-- Request a copy of the RITlug budget report from the clubs office. Print
-  sheets from the document as needed.
+- Request copy of RITlug budget report from Clubs office. Print sheets from
+  document as needed.
+
+
+.. _`rendered version`: https://media.readthedocs.org/pdf/ritlug-runbook/latest/ritlug-runbook.pdf
+.. _`RITlug/governance`: https://github.com/RITlug/governance
+.. _`these steps`: https://github.com/RITlug/governance#requirements


### PR DESCRIPTION
Continues addressing the runbook documentation explained in RITlug/tasks#8. This PR was minor updating and revisions to the sections on the club binder. No major reworking was done.

**+2 approved reviews to merge**