### PR TITLE
Update copyright to 2018, RITlug Executive Board

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'RIT Linux Users Group Runbook'
-copyright = '2017, Justin W. Flory, Solomon Rubin, Nate Levesque, Mark Repka, and others'
+copyright = '2017-2018, RITlug Executive Board'
 author = 'Justin W. Flory, Solomon Rubin, Nate Levesque, Mark Repka, and others'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Updates the copyright string to `2017-2018, RITlug Executive Board`. Even though all this text is licensed CC0… 🤔 

Since it's minor, I'm just going to merge.