### PR TITLE
Clarify election policy, use CampusGroups documentation (closes #36)

### DIFF
--- a/docs/administration/campusgroups-management.rst
+++ b/docs/administration/campusgroups-management.rst
@@ -113,51 +113,19 @@ Future eboards may choose to utilize CampusGroups in more detail.
 Hold elections
 **************
 
-Eboard elections must be held via CampusGroups.
+Elections must be held via CampusGroups.
 This is to combat corruption and embezzlement of RIT Clubs funding.
 CampusGroups standardizes student organization elections for consistency and fairness.
 
 Elections are a special type of survey in the *Surveys* menu.
+Refer to `CampusGroups documentation <https://help.campusgroups.com/forms-and-surveys/running-elections-for-your-group>`_ to create elections in CampusGroups.
 
-Create election
-===============
+Election execution
+==================
 
-.. note::
+.. seealso::
 
-   This section needs to be written
-
-.. todo::
-
-   - Remember details for question submission options, disable editing, etc.
-   - Configure any metadata as needed
-   - Screenshots!
-
-Configure candidates
-====================
-
-.. note::
-
-   This section needs to be written
-
-.. todo::
-
-   - Collect profile picture of candidate
-   - Offer opportunity to publish platform / campaign info
-   - Line up with deadlines for nomination calls (see on/off-boarding doc)
-
-Publish and announce
-====================
-
-.. note::
-
-   This section needs to be written
-
-.. todo::
-
-   - Make sure all options are final
-   - Open election, set expiration date/time
-   - Publish announcement (e.g. mailing list)
-   - After, update officers
+   See :doc:`eboard-onboarding-offboarding` for more information on election execution and policy.
 
 
 .. _`CampusGroups`: https://campusgroups.rit.edu

--- a/docs/administration/eboard-onboarding-offboarding.rst
+++ b/docs/administration/eboard-onboarding-offboarding.rst
@@ -32,7 +32,7 @@ Follow these steps to execute an election.
     
     - After accepting votes, close form, tally responses
     
-    - At Week 12 meeting, announce results and display anonymized results to club members in room
+    - At Week 12 meeting, announce results to club members in room; follow-up with an email announcment after
     
     - After announcing winners, current eboard should **permanently delete** the data associated with voting form (to protect voter identity)
 


### PR DESCRIPTION
This PR focuses on election execution inside of CampusGroups. This PR does a few things:

* Clarifies how eboard elections are announced (announce first in meeting, then email follow-up)
* Refer to CampusGroups documentation for how to actually create election in CG interface (thanks @axk4545 for finding this!)

---

_Tagging RITlug/tasks#8 for tracking purposes._