### PR TITLE
 Eboard transition: Follow style guide, update timeline, clarify off-boarding

### DIFF
--- a/docs/administration/eboard-onboarding-offboarding.rst
+++ b/docs/administration/eboard-onboarding-offboarding.rst
@@ -63,25 +63,33 @@ Arrange a meeting time for the outgoing and incoming eboard members to meet with
 Other on-boarding tasks
 =======================
 
-- Grant operator privileges to incoming eboard members in IRC channel (see how in :doc:`../infrastructure/irc-channel`).
+- Share Runbook with incoming eboard members, encourage questions and feedback on improving the Runbook
 
-- Add incoming eboard members as admins to `Facebook group`_
+- Incoming eboard members must take `financial certification test`_ from RIT clubs office (all eboard members **must be certified** to use club funds)
+
+- Add incoming eboard as Slack organization admins
+
+- Add incoming eboard to private Slack channel for eboard discussion
+
+- Add incoming eboard to new eboard team in GitHub organization, archive old eboard team, grant ownership privileges to president / vice president (see :doc:`github-org`)
+
+- Add incoming eboard members as collaborators with write access to the RITlug Google Drive folder
 
 - Transfer ownership of RIT computer account for RITlug (i.e. ritlug at rit dot edu)
 
-- Add incoming eboard to new eboard team in GitHub organization, archive old eboard team, grant ownership privileges to president / vice president (see :doc:`github-org` for detailed information)
+- Grant operator privileges to incoming eboard members in IRC channel (see :doc:`../infrastructure/irc-channel`).
 
-- Share Runbook with incoming eboard members, encourage questions and feedback on improving the Runbook
+- Add incoming eboard members as admins to `Telegram group`_ (*optional*, Telegram is no longer promoted)
+
+- Add incoming eboard members as admins to `Facebook group`_
 
 - *If new president*:
     
     - Pass off club binder at club office to new president
 
+    - Transfer ownership of RITlug Slack to new president
+
     - Transfer ownership of Google Drive folder to new president's RIT email
-
-- Add incoming eboard members as collaborators with write access to the RITlug Google Drive folder
-
-- Incoming eboard members must take `financial certification test`_ from RIT clubs office (all eboard members **must be certified** to use club funds)
 
 
 ****************************
@@ -92,20 +100,27 @@ These tasks are done at the discretion of incoming eboard members.
 All steps are recommended and encouraged, but not required.
 Use best judgment for whether access should be revoked (especially if outgoing members remain active members of RITlug).
 
-#. (**Required**) Remove permissions / roles in CampusGroups (see :doc:`campusgroups-management`)
+- (**Required**) Remove permissions / roles in CampusGroups (see :doc:`campusgroups-management`)
 
-#. Revoke account privileges from any RITlug-owned machines or servers (see :doc:`../infrastructure/hosted-server`)
+- Downgrade outgoing members from Slack organization admins to regular members
 
-#. Remove outgoing members from current "Eboard" team in GitHub, remove ownership rights if they have it
+- Remove outgoing members from private Slack channel for eboard discussion
 
-#. Revoke admin privileges on Facebook group
+- Remove outgoing members from current "Eboard" team in GitHub, remove ownership rights if they have it (see :doc:`github-org`)
 
-#. Remove channel operator privileges on IRC (optionally can grant voice privileges)
+- Revoke privileges in RITlug Google Drive folder
 
-#. Revoke privileges in RITlug Google Drive folder
+- Transfer account ownership of RIT computer account, update any info, reset password (if necessary)
 
-#. Transfer account ownership of RIT computer account, update any info, reset password (if necessary)
+- Remove channel operator privileges on IRC (optionally can grant voice privileges) (see :doc:`../infrastructure/irc-channel`)
+
+- Revoke admin privileges on `Telegram group`_ (if applicable)
+
+- Revoke admin privileges on `Facebook group`_
+
+- Revoke account privileges from any RITlug-owned machines or servers (see :doc:`../infrastructure/hosted-server`)
 
 
+.. _`Telegram group`: https://t.me/ritlug
 .. _`Facebook group`: https://www.facebook.com/groups/RITLUG/
 .. _`financial certification test`: https://www.rit.edu/studentaffairs/campuslife/financial-certification-test

--- a/docs/administration/eboard-onboarding-offboarding.rst
+++ b/docs/administration/eboard-onboarding-offboarding.rst
@@ -1,14 +1,18 @@
+####################
 Eboard transitioning
-====================
+####################
 
 This document explains how the exiting RITlug executive board (a.k.a. eboard) transitions to a new, incoming executive board.
 
 
+***************************
 On-boarding incoming eboard
----------------------------
+***************************
+
+These steps focus on how to on-board new members to RITlug's eboard.
 
 Elections
-^^^^^^^^^
+=========
 
 Elections are held towards the end of the spring semester.
 Running an annual election is required by the club office and should never be skipped.
@@ -18,7 +22,7 @@ Follow these steps to execute an election.
 
 - **Week 10**: Open call for nominations
   
-    - Open call for nominations, for club members to nominate others in the community to nominate others for eboard positions
+    - Open call for nominations: club members nominate others in community for eboard positions
   
     - Verify / confirm nominations with nominees
   
@@ -26,41 +30,40 @@ Follow these steps to execute an election.
 
 - **Week 12**: Hold elections during club meeting
 
-    - At start of Week 12, open election with all nominated candidates
+    - At start of Week 12 (Monday), open election with nominated candidates
     
-    - Accept votes in a Google Drive form that requires logins to vote (to prevent voter fraud); remind club members that voting is anonymous
+    - Create CampusGroups survey to accept votes (see :doc:`campusgroups-management` for more info); remind club members that voting is anonymous
     
-    - After accepting votes, close form, tally responses
-    
-    - At Week 12 meeting, announce results to club members in room; follow-up with an email announcment after
-    
-    - After announcing winners, current eboard should **permanently delete** the data associated with voting form (to protect voter identity)
+    - Close form at end of Week 12 (Sunday)
 
-Don't forget to congratulate all nominees for their participation in the election.
+    - Current eboard members reach out to winning members to confirm their acceptance of role
+    
+    - At Week 13 meeting, announce results to club members in room; follow-up with an email announcment after
 
+Congratulate all nominees for their participation in the election.
 
 CampusGroups roles
-^^^^^^^^^^^^^^^^^^
+==================
 
-All RIT clubs are required to use CampusGroups and maintain records there for the clubs office.
+RIT clubs are required to use CampusGroups and maintain records for the clubs office.
 After holding an election, update the incoming eboard members inside of CampusGroups.
 
 Detailed documentation on CampusGroups can be found on the :doc:`campusgroups-management` page.
 
-
 Introduce faculty adviser
-^^^^^^^^^^^^^^^^^^^^^^^^^
+=========================
 
-Outgoing eboard members should help incoming members maintain a relationship with the faculty adviser.
+Outgoing eboard members help incoming members maintain a relationship with the faculty adviser.
 Arrange a meeting time for the outgoing and incoming eboard members to meet with the faculty adviser.
 
-See more information on the :doc:`faculty-adviser` page.
+.. seealso::
 
+   See :doc:`faculty-adviser` for more information.
 
 Other on-boarding tasks
-^^^^^^^^^^^^^^^^^^^^^^^
+=======================
 
-- Grant operator privileges to incoming eboard members in the IRC channel (see how in :doc:`../infrastructure/irc-channel`).
+- Grant operator privileges to incoming eboard members in IRC channel (see how in :doc:`../infrastructure/irc-channel`).
 
 - Add incoming eboard members as admins to `Facebook group`_
 
@@ -68,32 +71,41 @@ Other on-boarding tasks
 
 - Add incoming eboard to new eboard team in GitHub organization, archive old eboard team, grant ownership privileges to president / vice president (see :doc:`github-org` for detailed information)
 
-- Share this Runbook with incoming eboard members, encourage questions and feedback on improving the Runbook
+- Share Runbook with incoming eboard members, encourage questions and feedback on improving the Runbook
 
 - *If new president*:
     
     - Pass off club binder at club office to new president
 
-    - Transfer ownership of Google Drive folder to new president
+    - Transfer ownership of Google Drive folder to new president's RIT email
 
 - Add incoming eboard members as collaborators with write access to the RITlug Google Drive folder
 
-- Incoming eboard members should take financial certification test from RIT clubs office (all eboard members **must be certified** to use club funds)
-
-.. _`Facebook group`: https://www.facebook.com/groups/RITLUG/
+- Incoming eboard members must take `financial certification test`_ from RIT clubs office (all eboard members **must be certified** to use club funds)
 
 
+****************************
 Off-boarding outgoing eboard
-----------------------------
+****************************
 
-These tasks are done at the discretion of the incoming eboard members.
-All steps are highly recommended, but are not required.
+These tasks are done at the discretion of incoming eboard members.
+All steps are recommended and encouraged, but not required.
 Use best judgment for whether access should be revoked (especially if outgoing members remain active members of RITlug).
 
-1. Revoke account privileges from any RITlug-owned machines or servers
-2. Remove outgoing members from current "Eboard" team in GitHub, remove ownership rights if they have it
-3. Revoke admin privileges on Facebook group
-4. Remove channel operator privileges on IRC (optionally can grant voice privileges)
-5. Remove permissions / roles in CampusGroups (see :doc:`campusgroups-management` for more information)
-6. Revoke privileges in RITlug Google Drive folder
-7. Transfer account ownership of RIT computer account, update any info and reset password (if necessary)
+#. (**Required**) Remove permissions / roles in CampusGroups (see :doc:`campusgroups-management`)
+
+#. Revoke account privileges from any RITlug-owned machines or servers (see :doc:`../infrastructure/hosted-server`)
+
+#. Remove outgoing members from current "Eboard" team in GitHub, remove ownership rights if they have it
+
+#. Revoke admin privileges on Facebook group
+
+#. Remove channel operator privileges on IRC (optionally can grant voice privileges)
+
+#. Revoke privileges in RITlug Google Drive folder
+
+#. Transfer account ownership of RIT computer account, update any info, reset password (if necessary)
+
+
+.. _`Facebook group`: https://www.facebook.com/groups/RITLUG/
+.. _`financial certification test`: https://www.rit.edu/studentaffairs/campuslife/financial-certification-test


### PR DESCRIPTION
## Review #39 first

This PR focuses on improving the eboard transition process. Specifically, it changes the following:

* Follow [style guide](https://documentation-style-guide-sphinx.readthedocs.io/en/latest/index.html) for Sphinx-based docs
* Clarifies election policy in context of CampusGroups (in a way, also closes #36)
* Emphasize a required step in off-boarding process (must be removed from CampusGroups)

---

_Tagging RITlug/tasks#8 for tracking purposes._