### PR TITLE
Faculty advisor: Follow style guide, reorganize / restructure content

### DIFF
--- a/docs/administration/faculty-adviser.rst
+++ b/docs/administration/faculty-adviser.rst
@@ -1,53 +1,62 @@
-Faculty Adviser
-===============
+###############
+Faculty advisor
+###############
 
-All official RIT clubs must have a faculty adviser.
-The faculty adviser is a more permanent position in the club and they are not subject to annual elections.
-
-The faculty adviser may change at any time during the year.
-If this happens, a new adviser should be found immediately (or else the club risks losing recognition by student government).
-Once found, the former adviser should be off-boarded and the new one on-boarded.
+This document explains the role of the faculty advisor in RITlug and how to on-board and off-board a faculty advisor.
 
 
-Adviser responsibilities
-------------------------
+*********************
+About faculty advisor
+*********************
 
-Faculty advisers can take a hands-on or hands-off role.
-In the past, RITlug's adviser is usually hands-off, assuming the club is well-behaved and there is regular communication with the adviser.
-If a new adviser is selected, they should meet with the current eboard and discuss expectations.
+All recognized RIT clubs must have a faculty advisor.
+The faculty advisor is a permanent position and not subject to annual elections.
 
-The adviser is a point of contact for the club and RIT clubs office.
-Thus, there are a few forms that the adviser must sign annually (usually at the beginning and end of the year).
-Periodically, the adviser may be needed to resolve issues with the clubs office or with renewing club resources.
+Responsibilities
+================
 
+Faculty advisors can take a hands-on or hands-off role.
+Historically, RITlug's advisor is hands-off.
+This assumes the club is in good standing is regular communication with the advisor.
+If a new advisor is selected, they should meet with the current eboard and discuss expectations.
 
-Adviser on-boarding
--------------------
-
-- Notify RIT clubs office to add new adviser to CampusGroups
-
-    - Clubs office sends email invitation they should accept
-
-    - Ask if other steps should be followed to bring in a new adviser, in case requirements by clubs office have changed [#]_
-
-- Instruct new adviser to contact RIT clubs office (they will be sent paperwork to formally accept role)
-
-- Follow eboard on-boarding procedures for faculty adviser (see :doc:`eboard-onboarding-offboarding`)
-
-- Organize formal meeting between current eboard and new adviser to communicate expectations and/or concerns
+The advisor is a point of contact for the club and RIT clubs office.
+Thus, there are a few forms that the advisor must sign annually (usually at the beginning and end of the year).
+Periodically, the advisor may need to resolve issues with the clubs office or with renewing club resources.
 
 
-Adviser off-boarding
---------------------
+*****************
+Changing advisors
+*****************
 
-*Note*: If off-boarding an adviser, ensure a new adviser is selected quickly.
-RITlug is an officially-recognized club and is required to have a faculty adviser at all times.
+The faculty advisor may change at any time during the year.
+If this happens, a new advisor must be found immediately (or else the club risks losing recognition by student government).
+RITlug is an officially-recognized club and is required to have a faculty advisor at all times.
+Once found, off-board the outgoing advisor and on-board the incoming advisor.
 
-- Contact clubs office to remove former adviser from CampusGroups
+Off-board outgoing advisor
+==========================
 
-- Follow eboard off-boarding procedures for faculty adviser (see :doc:`eboard-onboarding-offboarding`)
+- Request RIT clubs office to remove former advisor from CampusGroups
 
-- Thank your outgoing faculty adviser for their support (getting a physical gift, like a thank you card signed by club members or a gift card is a nice gesture)
+- Follow eboard off-boarding procedures for faculty advisor (see :doc:`eboard-onboarding-offboarding`)
+
+- Thank your outgoing faculty advisor for their support (physical gifts, like a thank you card signed by club members or a gift card, are nice gestures)
+
+On-board incoming advisor
+=========================
+
+- Request RIT clubs office to add new advisor to CampusGroups
+
+    - Office sends email invitation to new advisor
+
+    - Ask if other steps should be followed to bring in new advisor, in case requirements change [#]_
+
+- Instruct new advisor to contact RIT clubs office (they will be sent paperwork to formally accept role)
+
+- Follow eboard on-boarding procedures for faculty advisor (see :doc:`eboard-onboarding-offboarding`)
+
+- Organize formal meeting between current eboard and new advisor to communicate expectations and/or concerns
 
 
-.. [#] Always ask – RIT clubs office often does not clearly communicate when requirements have changed
+.. [#] Always ask – RIT clubs office does not directly communicate changes to requirements

--- a/docs/administration/faculty-adviser.rst
+++ b/docs/administration/faculty-adviser.rst
@@ -17,7 +17,7 @@ Responsibilities
 
 Faculty advisors can take a hands-on or hands-off role.
 Historically, RITlug's advisor is hands-off.
-This assumes the club is in good standing is regular communication with the advisor.
+This assumes the club is in good standing and is in regular communication with the advisor.
 If a new advisor is selected, they should meet with the current eboard and discuss expectations.
 
 The advisor is a point of contact for the club and RIT clubs office.


### PR DESCRIPTION
This PR addresses the faculty advisor page. There weren't many content changes in this one. Specifically, this PR changes the following:

* Follow [style guide](https://documentation-style-guide-sphinx.readthedocs.io/en/latest/index.html) for Sphinx-based docs
* Avoid passive voice / improve readability score
* Reorganize section on changing faculty advisors

![Rendered preview of updated faculty advisor page](https://user-images.githubusercontent.com/4721034/37867793-9162fc78-2f73-11e8-8e2c-7ca9b6952333.png)

---

_Tagging RITlug/tasks#8 for tracking purposes._