### PR TITLE
Improve club fairs page to be more detailed and accurate

### DIFF
--- a/docs/events/club-fairs.rst
+++ b/docs/events/club-fairs.rst
@@ -1,36 +1,115 @@
-Club Fairs
-==========
+##########
+Club fairs
+##########
 
-RIT has a number of club fairs throughout the year that RITlug can attend in order to attract more members.
-Attending (or not) is at the discretion of the active Eboard.
+RIT hosts several club fairs throughout the year.
+Since RITlug is a recognized student organization, RITlug can attend to attract new members.
+Event attendance is optional, but must be organized by the eboard.
 
+
+***************************
+Incoming students club fair
+***************************
+
+Three to four club fairs are held around the year.
+However, the club fair held for incoming students at the beginning of fall semester is the largest.
+This is the best way to attract interest from incoming freshmen or transfer students.
+This is an important event for RITlug to participate in.
+
+The incoming students club fair is usually held the weekend before the first day of classes.
+This falls towards the end of the week for freshman orientation.
+Participating members should plan an arrival to Rochester in time for the fair.
+
+To attend, clubs must fill out a registration form sent by the RIT clubs office towards the end of spring semester.
+The content of the form varies, but usually requests the following information:
+
+- Name / information about club
+
+- Number of participants at table (for chairs)
+
+- Whether power is needed
+
+The form is not complex, but must be filled out on time.
+Typically, the deadline is in the middle of summer.
+Watch for communication by the RIT clubs office towards the end of spring semester for more information.
+
+
+********
 Staffing
---------
+********
 
-The RITlug table must be staffed by at least one Eboard member.
-Eboard can offer staffing the table as a club involvement opportunity and any number of members can visit or stand with RITlug.
+Two eboard members are required to staff a table at a club fair.
+Three members are recommended, to better handle questions and take breaks.
+Additionally, general members can participate at the table as an involvement opportunity.
+Any number of members may participate, depending on the size of the fair.
 
 Anyone staffing the table should be prepared to speak to people.
+It is a good idea to think about the "elevator pitch" for the club before the fair.
+This can include what RITlug focuses on, what we do in our meetings, and any active projects in the club.
 
-Setup
------
+*********************
+Preparation and setup
+*********************
 
--  Sign up for the club fair using the relevant form on TheLink.
+Register for fair
+=================
 
--  Request extra chairs and access to power if needed.
+Follow these steps to register and prepare for the club fair first:
 
--  Put up the RITlug table banner if it is available.
-   Otherwise, try to have some signage on hand so the table is clearly branded as being a RITlug presence.
+#. Register for club fair (watch for RIT clubs office newsletters to register)
 
--  Create a signup sheet on Google Forms to collect the email addresses of anyone interested in getting involved.
-   Email should suffice, but name and email can be a good idea (new students may sign up with their personal email).
+#. Request chairs and access to power
 
-After the Fair
---------------
+#. Create sign-up form on Google Drive to collect email addresses of anyone interested (include name, email, year, interest areas)
 
--  Invite anyone who signed up with their RIT email to join RITlug on TheLink.
-   TheLink offers this functionality on the Roster under the Invite button.
+Packing list
+============
 
--  Email anyone who signed up with their personal email and suggest they join TheLink or the public mailing list for email updates.
-   You can also refer them to the get-involved page on the website, or equivalent.
-   Don't annoy them by emailing them repeatedly.
+Prepare for the club fair by assembling these items:
+
+- Tablecloth (x1)
+
+- Printed RITlug banner (x1)
+
+- Laptops (x2)
+
+- Monitors (x2)
+
+- USB keyboard (x1)
+
+- USB mouse (x1)
+
+- Printed brochures / handouts
+
+- Any projects to display
+
+Day-of setup
+============
+
+On the day of the club fair, follow these steps:
+
+#. Spread out tablecloth across table
+
+#. Hang RITlug banner across table
+
+#. Set up monitors and connect them to laptops
+
+#. Display club website on one monitor, Google Drive form on other
+
+   - Keyboard and mouse should be attached to laptop with Google Drive form
+
+
+*******************
+Post-fair follow-up
+*******************
+
+- Write personal email to new addresses to introduce them to club, website, how to get involved (as a one-time message)
+
+- Add email addresses from Google Drive form to Google Groups mailing list (see :doc:`../tasks/announcements`)
+
+Be careful about sending too many emails.
+Too many emails may have the inverse effect.
+
+Additionally, the RITlug eboard should hold a retrospective in the next eboard meeting to evaluate how it went.
+This Runbook page should be a part of the discussion.
+Be sure to update anything on this page based on how a club fair went or improvements for next time.


### PR DESCRIPTION
This commit specifically addresses the following:

* **Follow [style guide](https://documentation-style-guide-sphinx.readthedocs.io/en/latest/index.html) for Sphinx-based docs**
* **Add section specifically on club fair for incoming students**
* **Change requirements on staffing**
    * Two eboard members required
    * Suggestions for ways to prep for staffing booth
* **Rework preparation and setup section:**
    * Registering / preparing for fair
    * Add packing list
    * Detail day-of setup
* **Add note about retrospectives in post-fair follow-up**

![Rendered preview of club fairs page](https://user-images.githubusercontent.com/4721034/37868229-ac427ac2-2f79-11e8-9914-0e7d25cb0d55.png)

---

_Tagging RITlug/tasks#8 for tracking purposes._