### PR TITLE
Add new page: President role (closes #50)

### DIFF
--- a/docs/roles/president.rst
+++ b/docs/roles/president.rst
@@ -9,22 +9,46 @@ This page explains more about the responsibilities and role of the president.
 Description
 -----------
 
-< general description of role, 1-2 paragraphs >
+The president acts as a leader for the club to help determine strategy and focus for each academic year.
+The president uses the `RITlug/tasks <https://github.com/RITlug/tasks>`_ repository as their primary organizational tool. 
+This includes updating the `RITlug project board <https://github.com/orgs/RITlug/projects/1?fullscreen=true>`_
+The president works together with the eboard to work towards the goals and strategies for each semester. 
+Additionally, they can pick up tasks from other eboard members if they are overloaded.
+
+While it is the job of the president to carry out the main administrative tasks listed above, it is the vice president's job to assist where possible. 
+These items are the primary responsibilities of the president.
+The president is the main point of contact for all club-related functions.
 
 
 Eligibility requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-< basic eligiblity requirements – what if someone is on co-op? away from campus? working remote? is under academic suspension (i.e. low GPA)? >
+* Must be involved in the club for at least a year prior to election
+* Must be a full time student on main campus for at least one semester
+* Cannot be on academic probation
+* Must be present for **75% of weekly club meetings and eboard meetings**
 
 
 Responsibilities
 ----------------
 
-< responsibilities and routine work that someone in this position is directly accountable for – what do they do and what should other eboard members expect from this person? >
+* Updating the RITlug `project board <https://github.com/orgs/RITlug/projects/1?fullscreen=true>`_ and following up on current tasks
+* Liason for club conflicts
+* Reaching out to potential guest speakers
+* Creating and managing semester schedule
+* Reviewing and aiding in weekly presentations
+* Setting strategic direction and goals for an academic year (with input from other eboard members)
+* Acting as a liason between RITlug and other entities inside or outside of RIT
+* Sending / reviewing weekly announcements
+   * Vice president assists with this responsibility as needed
+* Maintaining semester presentation schedule
+   * Coordinating with eboard and club community to find potential guest speakers, reaching out to speakers
+* Planning internal / external events
+   * Club fair
+   * eboard / general meetings
 
 
 Resources
 ---------
 
-< any resources, pages, or other things someone coming into this should read to be informed and prepared to take on the role – probably best as a list of links! >
+* [...]


### PR DESCRIPTION
This PR adds documentation for the president role. A screenshot of the result is shown below:
![president_role](https://user-images.githubusercontent.com/22552344/45268848-8619f980-b451-11e8-89cb-287826cbd636.png)
![president_role2](https://user-images.githubusercontent.com/22552344/45268865-b3ff3e00-b451-11e8-94d2-d6442de039b0.png)





