### PR TITLE
Add instructions for CampusGroups meeting sign-in (closes #67)

### DIFF
--- a/docs/events/meetings.rst
+++ b/docs/events/meetings.rst
@@ -17,11 +17,13 @@ Pre-meeting
 
 #. Plan topic(s) for meeting
 
-#. Announce meeting and topic (see :doc:`../tasks/announcements`)
+#. :doc:`Announce meeting and topic <../tasks/announcements>`
 
 #. Prepare presentation, slides, or handouts
 
 #. Advertise special topics (e.g. posters)
+
+#. :doc:`Create sign-in form on CampusGroups <../tasks/create-campusgroups-signin>`
 
 Meeting
 =======

--- a/docs/tasks/create-campusgroups-signin.rst
+++ b/docs/tasks/create-campusgroups-signin.rst
@@ -1,0 +1,23 @@
+####################################
+How to create a meeting sign-in form
+####################################
+
+This guide explains how to create a meeting sign-in form on CampusGroups.
+Every meeting should have a sign-in form to track attendance and log club activity.
+This activity is used by RIT clubs office to determine club engagement (relevant for budget allocation).
+
+
+***********************
+How to create a meeting
+***********************
+
+Sign-in forms are tied to CampusGroups Events (found under the *Events* tab on the organization page).
+Regular meetings are created automatically via RIT's Event Management System (see :doc:`../events/event-management-system`).
+RITlug eboard members do not need to manually create meetings.
+
+
+************************************
+Where to find sign-in link / QR code
+************************************
+
+See the `official CampusGroups documentation <https://help.campusgroups.com/events-and-calendars/track-attendance/how-to-activate-the-qr-code-self-check-in-feature-to-your-event>`_ for help activating self check-in for events.


### PR DESCRIPTION
This PR adds basic instructions on how to create a CampusGroups sign-in form. I found "upstream" documentation from CampusGroups, so instead of us writing and maintaining this, I figured pointing to CampusGroups made more sense.

This closes #67 and contributes to RITlug/tasks#8.

![How to create a meeting sign-in form - rendered preview](https://user-images.githubusercontent.com/4721034/46921826-fe825600-cfcd-11e8-93da-cb9cfd37fc4d.png "How to create a meeting sign-in form - rendered preview")